### PR TITLE
Add CMakfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.12)
+project(PCADSch2KiCAD)
+
+set(CMAKE_C_STANDARD 11)
+
+set(SOURCES
+    KiCADOutputSchematic.c
+    Lexic.c
+    PCADEnums.c
+    PCADOutputSchematic.c
+    PCADParser.c
+    PCADProcessSchematic.c
+    Parser.c
+    main.c)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
+
+add_executable(PCADSch2KiCAD ${SOURCES})
+
+if(UNIX AND NOT APPLE)
+  install(TARGETS PCADSch2KiCAD DESTINATION /usr/bin)
+endif()

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+/*============================================================================*/
+/*
+ Copyright (c) 2024, Isaac Marino Bavaresco
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+	 * Redistributions of source code must retain the above copyright
+	   notice, this list of conditions and the following disclaimer.
+	 * Neither the name of the author nor the
+	   names of its contributors may be used to endorse or promote products
+	   derived from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE AUTHOR ''AS IS'' AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/*============================================================================*/


### PR DESCRIPTION
I tried to package pcadsch2kicad to the Arch Linux AUR repository, and found that codeblocks would report errors when compiled in PKGBUILD, so I submitted the cmake to solve the problems encountered during the packaging process.

```bash
  -> Creating working copy of pcadsch2kicad-git git repo...
Cloning into 'pcadsch2kicad-git'...
done.
==> Starting prepare()...
==> Starting pkgver()...
==> Starting build()...
Authorization required, but no authorization protocol specified

14:45:22: Error: Unable to initialize GTK+, is DISPLAY set properly?
==> ERROR: A failure occurred in build().
    Aborting...
==> ERROR: Build failed,
```